### PR TITLE
Added bootloader for GitHub issue task add button

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -17,7 +17,7 @@
   "content_scripts": [
     {
       "matches": ["https://*.github.com/*"],
-      "js": ["scripts/content_github.js"],
+      "js": ["scripts/content_github.js", "scripts/content_github_issues.js"],
       "css": ["styles/global.css", "styles/github.css"]
     },
     {

--- a/src/bootloader/github_issues.js
+++ b/src/bootloader/github_issues.js
@@ -1,0 +1,50 @@
+var HashMap = require('hashmap');
+var offset = require('document-offset');
+var ButtonState = require('../button/button');
+var observer = require('../utils/observer');
+
+var buttons = new HashMap();
+ 
+function createObserver() {
+  observer.create('.issue-title-link')
+    .onAdded(createButton)
+    .onRemoved(removeButton)
+    .start();
+}
+
+function createButton(title) {
+  var name = title.innerText;
+  
+  var state = new ButtonState({
+    task: { name: name }
+  });
+
+  var buttonEl = state.button.render().el;
+  title.appendChild(buttonEl);
+
+  state.on('popup:created', function() {
+    var popupEl = state.popup.render().el;
+    var position = offset(buttonEl);
+
+    popupEl.style.position = 'absolute';
+    popupEl.style.left = position.left + 'px';
+    popupEl.style.top = position.top + 'px';
+
+    document.body.appendChild(popupEl);
+  });
+
+  buttons.set(title, state);
+}
+
+function removeButton(node) {
+  var button = buttons.get(node);
+  if (button != null) button.remove();
+}
+ 
+function handleError(error) {
+  console.error(error);
+}
+ 
+ButtonState.initialize()
+  .then(createObserver)
+  .catch(handleError);


### PR DESCRIPTION
A very quick add of a TW button to the GitHub issues grid. I added a separate bootloader js file for this purpose as the DOM structure of the issue title link is slightly different to that of a GitHub milestone.