### PR TITLE
fix: update Plan label to Project

### DIFF
--- a/src/popup/task/content/project_field/index.js
+++ b/src/popup/task/content/project_field/index.js
@@ -8,12 +8,12 @@ export default function(props) {
   const field = new SelectField({
     ...props,
     tabIndex: 3,
-    heading: 'Plan',
+    heading: 'Project',
     headingIconClass: css.icon,
     iconView: IconView,
     getCollectionItems: () =>
       parent.workspace.projects.models.filter(m => !m.archived),
-    addButtonlabel: 'Add Plan',
+    addButtonlabel: 'Add Project',
     modelIdProp: 'plan_id',
     async addModel(name) {
       const project = await createProject(


### PR DESCRIPTION
Updates 'Plan' label to 'Project' to be consistent with the webapp.
https://linear.app/toggl-plan/issue/HERO-409/[browser-extension]-update-plan-label-to-project